### PR TITLE
fix bug interface conversion: interface {} is string, not []uint8  …

### DIFF
--- a/redisearch/client.go
+++ b/redisearch/client.go
@@ -268,7 +268,7 @@ func loadDocument(arr []interface{}, idIdx, scoreIdx, payloadIdx, fieldsIdx int)
 	if fieldsIdx > 0 {
 		lst := arr[idIdx+fieldsIdx].([]interface{})
 		for i := 0; i < len(lst); i += 2 {
-			prop := string(lst[i].([]byte))
+			prop := lst[i].(string)
 			var val interface{}
 			switch v := lst[i+1].(type) {
 			case []byte:


### PR DESCRIPTION
…as described in https://groups.google.com/d/topic/redisearch/xv2PLo2ettc/discussion