### PR TITLE
Develop

### DIFF
--- a/redisearch/client.go
+++ b/redisearch/client.go
@@ -275,7 +275,7 @@ func loadDocument(arr []interface{}, idIdx, scoreIdx, payloadIdx, fieldsIdx int)
 			default:
 				prop = lst[i].(string)
 			}
-			
+
 			var val interface{}
 			switch v := lst[i+1].(type) {
 			case []byte:
@@ -365,6 +365,15 @@ func (i *Client) Drop() error {
 	_, err := conn.Do("FT.DROP", i.name)
 	return err
 
+}
+
+// Delete the document from the index
+func (i *Client) Delete(docId string) error {
+	conn := i.pool.Get()
+	defer conn.Close()
+
+	_, err := conn.Do("FT.DEL", i.name, docId)
+	return err
 }
 
 // IndexInfo - Structure showing information about an existing index

--- a/redisearch/client.go
+++ b/redisearch/client.go
@@ -367,13 +367,18 @@ func (i *Client) Drop() error {
 
 }
 
-// Delete the document from the index
-func (i *Client) Delete(docId string) error {
+// Delete the document from the index, optionally delete the actual document
+func (i *Client) Delete(docId string, deleteDocument bool) (err error) {
 	conn := i.pool.Get()
 	defer conn.Close()
 
-	_, err := conn.Do("FT.DEL", i.name, docId)
-	return err
+	if deleteDocument {
+		_, err = conn.Do("FT.DEL", i.name, docId)
+	} else {
+		_, err = conn.Do("FT.DEL", i.name, docId, "DD")
+	}
+
+	return
 }
 
 // IndexInfo - Structure showing information about an existing index

--- a/redisearch/redisearch_test.go
+++ b/redisearch/redisearch_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mibes/redisearch-go/redisearch"
+	"github.com/RediSearch/redisearch-go/redisearch"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/redisearch/redisearch_test.go
+++ b/redisearch/redisearch_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/RediSearch/redisearch-go/redisearch"
+	"github.com/mibes/redisearch-go/redisearch"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -347,7 +347,44 @@ func TestSuggest(t *testing.T) {
 		assert.Contains(t, suggestion.Payload, "bar")
 		assert.NotZero(t, suggestion.Score)
 	}
+}
 
+func TestDelete(t *testing.T) {
+	c := createClient("testung")
+
+	sc := redisearch.NewSchema(redisearch.DefaultOptions).
+		AddField(redisearch.NewTextField("foo"))
+
+	err := c.Drop()
+	assert.Nil(t, err)
+	assert.Nil(t, c.CreateIndex(sc))
+
+	var info *redisearch.IndexInfo
+
+	// validate that the index is empty
+	info, err = c.Info()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(0), info.DocCount)
+
+	doc := redisearch.NewDocument("doc1", 1.0)
+	doc.Set("foo", "Hello world")
+
+	err = c.IndexOptions(redisearch.DefaultIndexingOptions, doc)
+	assert.Nil(t, err)
+
+	// now we should have 1 document (id = doc1)
+	info, err = c.Info()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(1), info.DocCount)
+
+	// delete the document from the index
+	err = c.Delete("doc1", true)
+	assert.Nil(t, err)
+
+	// validate that the index is empty again
+	info, err = c.Info()
+	assert.Nil(t, err)
+	assert.Equal(t, uint64(0), info.DocCount)
 }
 
 func ExampleClient() {


### PR DESCRIPTION
For one of our projects we needed the ability to delete documents from an existing index. This extension wraps the "FT.DEL" command with the optional "DD" flag.