### PR TITLE
[add] added helper method to escape text fields

### DIFF
--- a/redisearch/document.go
+++ b/redisearch/document.go
@@ -2,6 +2,11 @@ package redisearch
 
 import (
 	"sort"
+	"strings"
+)
+
+const (
+	field_tokenization = ",.<>{}[]\"':;!@#$%^&*()-+=~"
 )
 
 // Document represents a single document to be indexed or returned from a query.
@@ -31,6 +36,22 @@ func (d *Document) SetPayload(payload []byte) {
 func (d Document) Set(name string, value interface{}) Document {
 	d.Properties[name] = value
 	return d
+}
+
+// All punctuation marks and whitespaces (besides underscores) separate the document and queries into tokens.
+// e.g. any character of `,.<>{}[]"':;!@#$%^&*()-+=~` will break the text into terms.
+// So the text `foo-bar.baz...bag` will be tokenized into `[foo, bar, baz, bag]`
+// Escaping separators in both queries and documents is done by prepending a backslash to any separator.
+// e.g. the text `hello\-world hello-world` will be tokenized as `[hello-world, hello, world]`.
+// **NOTE** that in most languages you will need an extra backslash when formatting the document or query,
+// to signify an actual backslash, so the actual text in redis-cli for example, will be entered as `hello\\-world`.
+// Underscores (`_`) are not used as separators in either document or query.
+// So the text `hello_world` will remain as is after tokenization.
+func EscapeTextFileString(value string) (string) {
+	for _, char := range field_tokenization {
+		value = strings.Replace(value, string(char), ("\\"+string(char)), -1 )
+	}
+	return value
 }
 
 // DocumentList is used to sort documents by descending score

--- a/redisearch/document_test.go
+++ b/redisearch/document_test.go
@@ -1,0 +1,31 @@
+package redisearch_test
+
+import (
+	"github.com/RediSearch/redisearch-go/redisearch"
+	"testing"
+)
+
+func TestEscapeTextFileString(t *testing.T) {
+	type args struct {
+		value string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"url", args{"https://en.wikipedia.org/wiki",}, "https\\://en\\.wikipedia\\.org/wiki",
+		},
+		{
+			"hello_world", args{"hello_world",}, "hello_world",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := redisearch.EscapeTextFileString(tt.args.value); got != tt.want {
+				t.Errorf("EscapeTextFileString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
following https://github.com/RediSearch/RediSearch/commit/dccd1447d5f3399ff5ca90bc3f92c6d636167a9c added Text Field Tokenization helper method. 

Considering `string.ReplaceAll` was introduced only in  [Go 1.12](https://golang.org/doc/go1.12#targetText=The%20new%20function%20ReplaceAll%20returns,the%20latter%20in%20all%20cases.) this PR makes usage of `string.Replace`. 
