### PR TITLE
fix bug aggregate and fix bug limit

### DIFF
--- a/redisearch/query.go
+++ b/redisearch/query.go
@@ -38,13 +38,13 @@ type SortingKey struct {
 
 func NewSortingKeyDir(field string, ascending bool) *SortingKey {
 	return &SortingKey{
-		Field: field,
+		Field:     field,
 		Ascending: ascending,
 	}
 }
 
 func (s SortingKey) Serialize() redis.Args {
-	args := redis.Args{ s.Field }
+	args := redis.Args{s.Field}
 	if s.Ascending {
 		args = args.Add("ASC")
 	} else {
@@ -98,7 +98,7 @@ type Paging struct {
 func NewPaging(offset int, num int) *Paging {
 	return &Paging{
 		Offset: offset,
-		Num: num,
+		Num:    num,
 	}
 }
 
@@ -106,7 +106,8 @@ func (p Paging) serialize() redis.Args {
 	args := redis.Args{}
 	// only serialize something if it's different than the default
 	// The default is 0 10
-	if p.Offset != DefaultOffset || p.Num != DefaultNum {
+	// when either offset or num is default number, then need to set limit too
+	if !(p.Offset == DefaultOffset && p.Num == DefaultNum) {
 		args = args.Add("LIMIT", p.Offset, p.Num)
 	}
 	return args
@@ -166,7 +167,7 @@ func (q Query) serialize() redis.Args {
 	}
 
 	if q.SortBy != nil {
-		args = args.Add("SORTBY").AddFlat( q.SortBy.Serialize() )
+		args = args.Add("SORTBY").AddFlat(q.SortBy.Serialize())
 	}
 
 	if q.HighlightOpts != nil {


### PR DESCRIPTION
-I want to fix two bug: 
case when aggregate returns only 1 data grouped, when do aggregate groupby reducer function on CLI, it returns 1 data. but when do in Golang code, it returns empty data, but total = 1, and err is nil. then I try to set if total > 0 , then return aggregate response, total 1, and err nil expected.

case 2: when I want to select limit 0 2, it returns default limit 0 10. then try to debug, found that if limit serialise only shown when (offset != 0 && num != 10).  If either offset 0, or num is default, then actual is no limit append on the quest stmt. example limit 0 2. when I fix the if condition, it return exactly limit 0 2 and returns expected response search 