### PR TITLE
Support for INFIELDS

### DIFF
--- a/redisearch/query.go
+++ b/redisearch/query.go
@@ -1,8 +1,9 @@
 package redisearch
 
 import (
-	"github.com/gomodule/redigo/redis"
 	"math"
+
+	"github.com/gomodule/redigo/redis"
 )
 
 // Flag is a type for query flags
@@ -82,6 +83,7 @@ type Query struct {
 
 	Filters       []Filter
 	InKeys        []string
+	InFields      []string
 	ReturnFields  []string
 	Language      string
 	Expander      string
@@ -150,6 +152,11 @@ func (q Query) serialize() redis.Args {
 	if q.InKeys != nil {
 		args = args.Add("INKEYS", len(q.InKeys))
 		args = args.AddFlat(q.InKeys)
+	}
+
+	if q.InFields != nil {
+		args = args.Add("INFIELDS", len(q.InFields))
+		args = args.AddFlag(q.InFields)
 	}
 
 	if q.ReturnFields != nil {
@@ -264,6 +271,12 @@ func (q *Query) SetFlags(flags Flag) *Query {
 // SetInKeys sets the INKEYS argument of the query - limiting the search to a given set of IDs
 func (q *Query) SetInKeys(keys ...string) *Query {
 	q.InKeys = keys
+	return q
+}
+
+// SetInFields sets the INFIELDS argument of the query - filter the results to ones appearing only in specific fields of the document
+func (q *Query) SetInFields(fields ...string) *Query {
+	q.InFields = fields
 	return q
 }
 

--- a/redisearch/query.go
+++ b/redisearch/query.go
@@ -156,7 +156,7 @@ func (q Query) serialize() redis.Args {
 
 	if q.InFields != nil {
 		args = args.Add("INFIELDS", len(q.InFields))
-		args = args.AddFlag(q.InFields)
+		args = args.AddFlat(q.InFields)
 	}
 
 	if q.ReturnFields != nil {

--- a/redisearch/query_test.go
+++ b/redisearch/query_test.go
@@ -68,6 +68,7 @@ func TestQuery_serialize(t *testing.T) {
 		Raw           string
 		Flags         Flag
 		InKeys        []string
+		InFields      []string
 		ReturnFields  []string
 		Language      string
 		Expander      string
@@ -89,6 +90,7 @@ func TestQuery_serialize(t *testing.T) {
 		{"QueryWithPayloads", fields{Raw: raw, Flags: QueryWithPayloads}, redis.Args{raw, "LIMIT", 0, 0, "WITHPAYLOADS"}},
 		{"QueryWithScores", fields{Raw: raw, Flags: QueryWithScores}, redis.Args{raw, "LIMIT", 0, 0, "WITHSCORES"}},
 		{"InKeys", fields{Raw: raw, InKeys: []string{"test_key"}}, redis.Args{raw, "LIMIT", 0, 0, "INKEYS", 1, "test_key"}},
+		{"InFields", fields{Raw: raw, InFields: []string{"test_key"}}, redis.Args{raw, "LIMIT", 0, 0, "INFIELDS", 1, "test_key"}},
 		{"ReturnFields", fields{Raw: raw, ReturnFields: []string{"test_field"}}, redis.Args{raw, "LIMIT", 0, 0, "RETURN", 1, "test_field"}},
 		{"Language", fields{Raw: raw, Language: "chinese"}, redis.Args{raw, "LIMIT", 0, 0, "LANGUAGE", "chinese"}},
 		{"Expander", fields{Raw: raw, Expander: "test_expander"}, redis.Args{raw, "LIMIT", 0, 0, "EXPANDER", "test_expander"}},
@@ -113,6 +115,7 @@ func TestQuery_serialize(t *testing.T) {
 				Raw:           tt.fields.Raw,
 				Flags:         tt.fields.Flags,
 				InKeys:        tt.fields.InKeys,
+				InFields:      tt.fields.InFields,
 				ReturnFields:  tt.fields.ReturnFields,
 				Language:      tt.fields.Language,
 				Expander:      tt.fields.Expander,


### PR DESCRIPTION
Added support for the INFIELDS query parameter:
If set, filter the results to ones appearing only in specific fields of the document, like title or URL. num is the number of specified field arguments