### PR TITLE
Fixed tests internal method to retrieve module version

### DIFF
--- a/redisearch/client_test.go
+++ b/redisearch/client_test.go
@@ -40,7 +40,7 @@ func (c *Client) getRediSearchVersion() (version int64, err error) {
 		if err != nil {
 			return
 		}
-		if moduleName == "ft" {
+		if moduleName == "search" {
 			version, err = redis.Int64(moduleInfo[3], err)
 		}
 	}


### PR DESCRIPTION
This PR fixes the current CI failures. It's an easy fix around our test specific method to get the current module version.