### PR TITLE
Added support for SLOP

### DIFF
--- a/redisearch/query.go
+++ b/redisearch/query.go
@@ -79,7 +79,7 @@ type Query struct {
 
 	Paging Paging
 	Flags  Flag
-	Slop   int
+	Slop   *int
 
 	Filters       []Filter
 	InKeys        []string
@@ -137,6 +137,10 @@ func (q Query) serialize() redis.Args {
 
 	if q.Flags&QueryNoContent != 0 {
 		args = args.Add("NOCONTENT")
+	}
+
+	if q.Slop != nil {
+		args = args.Add("SLOP", *q.Slop)
 	}
 
 	if q.Flags&QueryInOrder != 0 {


### PR DESCRIPTION
Added support for SLOP. Changed the int to an *int pointer (nullable) because SLOP 0 is a valid activity. The existing slop int attribute of the query struct was completely unused/unreferenced previously.