### PR TITLE
Fix issue #133 types not being recogized properly

### DIFF
--- a/redisearch/client.go
+++ b/redisearch/client.go
@@ -499,6 +499,10 @@ func (info *IndexInfo) loadSchema(values []interface{}, options []string) {
 
 		f := Field{Name: spec[0]}
 		switch strings.ToUpper(spec[2]) {
+		case "TAG":
+			f.Type = TagField
+		case "GEO":
+			f.Type = GeoField
 		case "NUMERIC":
 			f.Type = NumericField
 			nfOptions := NumericFieldOptions{}

--- a/redisearch/client.go
+++ b/redisearch/client.go
@@ -511,7 +511,6 @@ func (info *IndexInfo) loadSchema(values []interface{}, options []string) {
 		case "NUMERIC":
 			f.Type = NumericField
 			nfOptions := NumericFieldOptions{}
-			f.Options = nfOptions
 			if sliceIndex(options, "SORTABLE") != -1 {
 				nfOptions.Sortable = true
 			}

--- a/redisearch/client.go
+++ b/redisearch/client.go
@@ -501,6 +501,11 @@ func (info *IndexInfo) loadSchema(values []interface{}, options []string) {
 		switch strings.ToUpper(spec[2]) {
 		case "TAG":
 			f.Type = TagField
+			tfOptions := TagFieldOptions{}
+			if wIdx := sliceIndex(options, "SEPARATOR"); wIdx != -1 {
+				tfOptions.Separator = options[wIdx+1][0]
+			}
+			f.Options = tfOptions
 		case "GEO":
 			f.Type = GeoField
 		case "NUMERIC":
@@ -510,10 +515,10 @@ func (info *IndexInfo) loadSchema(values []interface{}, options []string) {
 			if sliceIndex(options, "SORTABLE") != -1 {
 				nfOptions.Sortable = true
 			}
+			f.Options = nfOptions
 		case "TEXT":
 			f.Type = TextField
 			tfOptions := TextFieldOptions{}
-			f.Options = tfOptions
 			if sliceIndex(options, "SORTABLE") != -1 {
 				tfOptions.Sortable = true
 			}
@@ -522,6 +527,7 @@ func (info *IndexInfo) loadSchema(values []interface{}, options []string) {
 				weight64, _ := strconv.ParseFloat(weightString, 32)
 				tfOptions.Weight = float32(weight64)
 			}
+			f.Options = tfOptions
 		}
 		sc = sc.AddField(f)
 	}

--- a/redisearch/client_test.go
+++ b/redisearch/client_test.go
@@ -901,12 +901,22 @@ func TestClient_CreateIndex(t *testing.T) {
 
 	// Create a schema
 	schema := NewSchema(DefaultOptions).
-		AddField(NewTagField("tags")).
-		AddField(NewGeoField("geo")).
-		AddField(NewTextFieldOptions(
-			"name",
-			TextFieldOptions{Sortable: true, PhoneticMatcher: PhoneticDoubleMetaphoneEnglish})).
-		AddField(NewNumericField("age"))
+		AddField(NewGeoField("geo")). // There are no useful opttions for geo field at this time
+		AddField(
+			NewTagFieldOptions(
+				"tags",
+				TagFieldOptions{Separator: '|'},
+			)).
+		AddField(
+			NewTextFieldOptions(
+				"name",
+				TextFieldOptions{Sortable: true, PhoneticMatcher: PhoneticDoubleMetaphoneEnglish},
+			)).
+		AddField(
+			NewNumericFieldOptions(
+				"age",
+				NumericFieldOptions{Sortable: true},
+			))
 
 	// IndexDefinition is available for RediSearch 2.0+
 	// In this example we will only index keys started by product:
@@ -918,9 +928,9 @@ func TestClient_CreateIndex(t *testing.T) {
 
 	// Create docs with a name that has the same phonetic matcher
 	vanillaConnection := c.pool.Get()
-	_, err = vanillaConnection.Do("HSET", "create-index-info:doc1", "name", "Jon", "age", 25, "tags", "tag1,tag2", "geo", "40.7222756,-73.9977894")
+	_, err = vanillaConnection.Do("HSET", "create-index-info:doc1", "name", "Jon", "age", 25, "tags", "tag1|tag2", "geo", "40.7222756,-73.9977894")
 	assert.Nil(t, err)
-	_, err = vanillaConnection.Do("HSET", "create-index-info:doc2", "name", "John", "age", 20, "tags", "tag1,tag2", "geo", "40.7222756,-73.9977894")
+	_, err = vanillaConnection.Do("HSET", "create-index-info:doc2", "name", "John", "age", 20, "tags", "tag1|tag2", "geo", "40.7222756,-73.9977894")
 	assert.Nil(t, err)
 
 	// Wait for all documents to be indexed
@@ -947,10 +957,14 @@ func TestClient_CreateIndex(t *testing.T) {
 		switch {
 		case f.Name == "age":
 			assert.Equal(t, 1, int(f.Type))
+			assert.Equal(t, true, f.Options.(NumericFieldOptions).Sortable)
 		case f.Name == "name":
 			assert.Equal(t, 0, int(f.Type))
+			assert.Equal(t, true, f.Options.(TextFieldOptions).Sortable)
 		case f.Name == "tags":
 			assert.Equal(t, 3, int(f.Type))
+			// Verify that the tags separators is | or 0x7c
+			assert.Equal(t, uint8(0x7c), f.Options.(TagFieldOptions).Separator)
 		case f.Name == "geo":
 			assert.Equal(t, 2, int(f.Type))
 		}

--- a/redisearch/client_test.go
+++ b/redisearch/client_test.go
@@ -901,7 +901,11 @@ func TestClient_CreateIndex(t *testing.T) {
 
 	// Create a schema
 	schema := NewSchema(DefaultOptions).
-		AddField(NewTextFieldOptions("name", TextFieldOptions{Sortable: true, PhoneticMatcher: PhoneticDoubleMetaphoneEnglish})).
+		AddField(NewTagField("tags")).
+		AddField(NewGeoField("geo")).
+		AddField(NewTextFieldOptions(
+			"name",
+			TextFieldOptions{Sortable: true, PhoneticMatcher: PhoneticDoubleMetaphoneEnglish})).
 		AddField(NewNumericField("age"))
 
 	// IndexDefinition is available for RediSearch 2.0+
@@ -914,9 +918,9 @@ func TestClient_CreateIndex(t *testing.T) {
 
 	// Create docs with a name that has the same phonetic matcher
 	vanillaConnection := c.pool.Get()
-	_, err = vanillaConnection.Do("HSET", "create-index-info:doc1", "name", "Jon", "age", 25)
+	_, err = vanillaConnection.Do("HSET", "create-index-info:doc1", "name", "Jon", "age", 25, "tags", "tag1,tag2", "geo", "40.7222756,-73.9977894")
 	assert.Nil(t, err)
-	_, err = vanillaConnection.Do("HSET", "create-index-info:doc2", "name", "John", "age", 20)
+	_, err = vanillaConnection.Do("HSET", "create-index-info:doc2", "name", "John", "age", 20, "tags", "tag1,tag2", "geo", "40.7222756,-73.9977894")
 	assert.Nil(t, err)
 
 	// Wait for all documents to be indexed
@@ -937,6 +941,20 @@ func TestClient_CreateIndex(t *testing.T) {
 	assert.Equal(t, 2, total)
 	assert.Equal(t, "Jon", docs[0].Properties["name"])
 	assert.Equal(t, "John", docs[1].Properties["name"])
+
+	// Verify that each of the field types is correct
+	for _, f := range info.Schema.Fields {
+		switch {
+		case f.Name == "age":
+			assert.Equal(t, 1, int(f.Type))
+		case f.Name == "name":
+			assert.Equal(t, 0, int(f.Type))
+		case f.Name == "tags":
+			assert.Equal(t, 3, int(f.Type))
+		case f.Name == "geo":
+			assert.Equal(t, 2, int(f.Type))
+		}
+	}
 }
 
 func TestClient_CreateJsonIndex(t *testing.T) {


### PR DESCRIPTION
Fixes issues with typing of GEO and TAG fields in the Info function

https://github.com/RediSearch/redisearch-go/issues/133

@gkorland 