### PR TITLE
Fields were change from Fields to attributes 

### DIFF
--- a/redisearch/client.go
+++ b/redisearch/client.go
@@ -560,6 +560,9 @@ func (i *Client) Info() (*IndexInfo, error) {
 			indexOptions, _ = redis.Strings(res[ii+1], nil)
 		case "fields":
 			schemaFields, _ = redis.Values(res[ii+1], nil)
+		// In newer versions of Redis, the fields have been renamed to attributes
+		case "attributes":
+			schemaFields, _ = redis.Values(res[ii+1], nil)
 		}
 	}
 


### PR DESCRIPTION
This pulls in the newer attributes as the Fields to keep compatability

https://github.com/RediSearch/redisearch-go/issues/141