### PR TITLE
add new command EXPIRE

### DIFF
--- a/redisearch/document.go
+++ b/redisearch/document.go
@@ -17,6 +17,7 @@ type Document struct {
 	Id         string
 	Score      float32
 	Payload    []byte
+	TTL        int
 	Properties map[string]interface{}
 }
 
@@ -67,6 +68,12 @@ func (d *Document) SetPayload(payload []byte) {
 // Set sets a property and its value in the document
 func (d Document) Set(name string, value interface{}) Document {
 	d.Properties[name] = value
+	return d
+}
+
+// SetTTL sets the ttl and its option in the document
+func (d Document) SetTTL(ttl int) Document {
+	d.TTL = ttl
 	return d
 }
 

--- a/redisearch/query.go
+++ b/redisearch/query.go
@@ -445,6 +445,18 @@ func (i *Client) IndexOptions(opts IndexingOptions, docs ...Document) error {
 
 			return merr
 		}
+		if doc.TTL > 0 {
+			argsttl := make(redis.Args, 0, 2)
+			argsttl = append(argsttl, doc.Id, doc.TTL)
+			if err := conn.Send("EXPIRE", argsttl...); err != nil {
+				if merr == nil {
+					merr = NewMultiError(len(docs))
+				}
+				merr[ii] = err
+
+				return merr
+			}
+		}
 		n++
 	}
 


### PR DESCRIPTION
For my project, [`falcosidekick-ui`](https://github.com/falcosecurity/falcosidekick-ui) I use `redisearch` as storage for the events, it works really well but the community asked me to [add a TTL to keys](https://github.com/falcosecurity/falcosidekick-ui/issues/54). It's not currently possible in this SDK, so updated the `Document` structure with a new field `TTL` and created a method `SetTTL`. I tested my fork in my program, and it works

```
127.0.0.1:6379> keys *
1) "event:1656512211824943"
2) "event:1656512211824021"
127.0.0.1:6379> TTL event:1656512211824021
(integer) 91
127.0.0.1:6379> TTL event:1656512211824021
(integer) 85
```


Signed-off-by: Issif <issif+github@gadz.org>