### PR TITLE
Fixing index creation: CASESENSITIVE preceeds SORTABLE

### DIFF
--- a/redisearch/client_test.go
+++ b/redisearch/client_test.go
@@ -1227,7 +1227,8 @@ func TestClient_InfoFieldsTest(t *testing.T) {
 		AddField(NewGeoField("geo")).
 		AddField(NewNumericField("numeric")).
 		AddField(NewTextFieldOptions("alias_type", TextFieldOptions{As: "type", Sortable: true, NoIndex: true, NoStem: true})).
-		AddField(NewTagFieldOptions("address_city", TagFieldOptions{As: "city"}))
+		AddField(NewTagFieldOptions("address_city", TagFieldOptions{As: "city"})).
+		AddField(NewTagFieldOptions("type", TagFieldOptions{As: "tag", Sortable: true, CaseSensitive: true, NoIndex: true}))
 	// In this example we will only index keys started by product:
 	indexDefinition := NewIndexDefinition().AddPrefix("ft-info-fields-test:")
 	// Add the Index Definition
@@ -1245,6 +1246,7 @@ func TestClient_InfoFieldsTest(t *testing.T) {
 				Field{Name: "numeric", Type: 1, Sortable: false, Options: NumericFieldOptions{Sortable: false, NoIndex: false, As: "numeric"}},
 				Field{Name: "alias_type", Type: 0, Sortable: true, Options: TextFieldOptions{Weight: 1, Sortable: true, NoStem: true, NoIndex: true, PhoneticMatcher: "", As: "type"}},
 				Field{Name: "address_city", Type: 3, Sortable: false, Options: TagFieldOptions{Separator: 44, NoIndex: false, Sortable: false, CaseSensitive: false, As: "city"}},
+				Field{Name: "type", Type: 3, Sortable: true, Options: TagFieldOptions{Separator: 44, NoIndex: true, Sortable: true, CaseSensitive: true, As: "tag"}},
 			}),
 		info.Schema.Fields)
 }

--- a/redisearch/schema.go
+++ b/redisearch/schema.go
@@ -422,14 +422,14 @@ func serializeField(f Field, args redis.Args) (argsOut redis.Args, err error) {
 			if opts.Separator != 0 {
 				argsOut = append(argsOut, "SEPARATOR", fmt.Sprintf("%c", opts.Separator))
 			}
+			if opts.CaseSensitive {
+				argsOut = append(argsOut, "CASESENSITIVE")
+			}
 			if opts.Sortable {
 				argsOut = append(argsOut, "SORTABLE")
 			}
 			if opts.NoIndex {
 				argsOut = append(argsOut, "NOINDEX")
-			}
-			if opts.CaseSensitive {
-				argsOut = append(argsOut, "CASESENSITIVE")
 			}
 		}
 	case GeoField:


### PR DESCRIPTION
`CASESENSITIVE` label should be declared before `SORTABLE`:
```
127.0.0.1:6379>  FT.CREATE ft-info-fields-test ON HASH PREFIX 1 ft-info-fields-test: SCHEMA t as tag TAG SEPARATOR "." SORTABLE CASESENSITIVE
(error) Field `CASESENSITIVE` does not have a type
127.0.0.1:6379>  FT.CREATE ft-info-fields-test ON HASH PREFIX 1 ft-info-fields-test: SCHEMA t as tag TAG SEPARATOR "." CASESENSITIVE SORTABLE
OK
```