### PR TITLE
Removing LGTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Codecov](https://codecov.io/gh/RediSearch/redisearch-go/branch/master/graph/badge.svg)](https://codecov.io/gh/RediSearch/redisearch-go)
 [![Go Report Card](https://goreportcard.com/badge/github.com/RediSearch/redisearch-go)](https://goreportcard.com/report/github.com/RediSearch/redisearch-go)
 [![GoDoc](https://godoc.org/github.com/RediSearch/redisearch-go?status.svg)](https://godoc.org/github.com/RediSearch/redisearch-go)
-[![Total alerts](https://img.shields.io/lgtm/alerts/g/RediSearch/redisearch-go.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/RediSearch/redisearch-go/alerts/)
 
 # RediSearch Go Client
 [![Forum](https://img.shields.io/badge/Forum-RediSearch-blue)](https://forum.redislabs.com/c/modules/redisearch/)


### PR DESCRIPTION
The LGTM service is being shut off in two weeks. This pull request aims to remove all references to LGTM. Perhaps LGTM usage should be replaced with codeql, or a repository preferred tool, but IMHO that's the point of a different pull request.