### PR TITLE
Update README.md with v2 tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Go client for [RediSearch](http://redisearch.io), based on redigo.
 # Installing
 
 ```sh
-go get github.com/RediSearch/redisearch-go/redisearch
+go get github.com/RediSearch/redisearch-go/v2/redisearch
 ```
 
 # Usage Example
@@ -27,7 +27,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/RediSearch/redisearch-go/redisearch"
+	"github.com/RediSearch/redisearch-go/v2/redisearch"
 )
 
 func ExampleClient() {


### PR DESCRIPTION
I had some issues figuring out how to use the v2 library. I updated the docs to reflect how I use it.

I made an assumption that v2 is the main supported library and updated the README.md.