### PR TITLE
use ConnPool in NewClientFromPool instead *redis.Pool

### DIFF
--- a/redisearch/client.go
+++ b/redisearch/client.go
@@ -39,7 +39,7 @@ func NewClient(addr, name string) *Client {
 }
 
 // NewClientFromPool creates a new Client with the given pool and index name
-func NewClientFromPool(pool *redis.Pool, name string) *Client {
+func NewClientFromPool(pool ConnPool, name string) *Client {
 	ret := &Client{
 		pool: pool,
 		name: name,


### PR DESCRIPTION
Using `ConnPool` instead of `*redis.Pool` will make Pool from `NewSingleHostPool` and `NewMultiHostPool` can be reused for multiple clients. 

This also can be used to resolve https://github.com/RediSearch/redisearch-go/issues/135