### PR TITLE
Prevent panic when lst (arr[idIdx+fieldsIdx]) is nil in loadDocument()

### DIFF
--- a/redisearch/document.go
+++ b/redisearch/document.go
@@ -105,8 +105,9 @@ func loadDocument(arr []interface{}, idIdx, scoreIdx, payloadIdx, fieldsIdx int)
 	}
 
 	if fieldsIdx > 0 {
-		lst := arr[idIdx+fieldsIdx].([]interface{})
-		doc.loadFields(lst)
+		if lst, ok := arr[idIdx+fieldsIdx].([]interface{}); ok {
+			doc.loadFields(lst)
+		}
 	}
 
 	return doc, nil


### PR DESCRIPTION
When using Search(), loadDocument is called where it loads fields and values through type casting. However, it doesn't do a nil check before casting `arr[idIdx+fieldsIdx]` into a `[]interface{}`. Under specific circumstances without a comma ok check, the library will panic with the error `panic: interface conversion: interface {} is nil, not []interface {}`. This PR adds a comma ok check before casting lst to `[]interface{}`.