### PR TITLE
Adding Payload Support for Query

### DIFF
--- a/redisearch/query.go
+++ b/redisearch/query.go
@@ -177,6 +177,10 @@ func (q Query) serialize() redis.Args {
 		args = args.AddFlat(q.ReturnFields)
 	}
 
+	if q.Payload != nil {
+		args = args.Add("PAYLOAD", q.Payload)
+	}
+
 	if q.Scorer != "" {
 		args = args.Add("SCORER", q.Scorer)
 	}


### PR DESCRIPTION
Even though payload field is provided and can be set for Query object, while using Search function, the client does not send the payload for the query to Redis. This is because the "PAYLOAD" argument is not given to the client querying Redis.